### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,5 +1,10 @@
 name: Test and Release
 
+permissions:
+  contents: read
+  pull-requests: write
+  packages: write
+
 env:
   MAIN_REF: refs/heads/main
 


### PR DESCRIPTION
Potential fix for [https://github.com/bitcoin-ui-kit/bitcoin-ui/security/code-scanning/1](https://github.com/bitcoin-ui-kit/bitcoin-ui/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating release pull requests.
- `packages: write` for publishing packages to npm.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`test-and-release`) to limit permissions to that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
